### PR TITLE
Provider-controlled invitation expiry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'god', require: false
 source 'https://rails-assets.org' do
   gem 'rails-assets-semantic-ui', '~> 1.0'
   gem 'rails-assets-jquery', '~> 1.11'
+  gem 'rails-assets-pickadate', '~> 3.5', '!= 3.5.5'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'timecop'
   gem 'capybara'
-  gem 'capybara-webkit'
+  gem 'poltergeist'
   gem 'database_cleaner'
   gem 'aaf-gumboot', git: 'https://github.com/ausaccessfed/aaf-gumboot',
                      branch: 'develop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ausaccessfed/aaf-lipstick
-  revision: 8e80387cbec8217cea6bb07d4a28a5d9c0619b03
+  revision: 4e1c240b2adf512900b0e365433d9f044d215ab9
   branch: develop
   specs:
     aaf-lipstick (1.1.0)
@@ -201,6 +201,8 @@ GEM
       railties (= 4.2.0)
       sprockets-rails
     rails-assets-jquery (1.11.2)
+    rails-assets-pickadate (3.5.4)
+      rails-assets-jquery (>= 1.7)
     rails-assets-semantic-ui (1.11.4)
       rails-assets-jquery (>= 1.8)
     rails-deprecated_sanitizer (1.0.3)
@@ -361,6 +363,7 @@ DEPENDENCIES
   pry
   rails (~> 4.2.0)
   rails-assets-jquery (~> 1.11)!
+  rails-assets-pickadate (~> 3.5, != 3.5.5)!
   rails-assets-semantic-ui (~> 1.0)!
   rapid-rack
   redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,11 +85,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.4.1)
-      capybara (>= 2.3.0, < 2.5.0)
-      json
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    cliver (0.3.2)
     coderay (1.1.0)
     database_cleaner (1.4.1)
     diff-lcs (1.2.5)
@@ -181,6 +179,11 @@ GEM
       shellany (~> 0.0)
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -333,6 +336,9 @@ GEM
     url_safe_base64 (0.2.2)
     valhammer (0.1.2)
       activerecord (~> 4.1)
+    websocket-driver (0.5.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -346,7 +352,6 @@ DEPENDENCIES
   audited-activerecord
   brakeman (~> 2.6)
   capybara
-  capybara-webkit
   database_cleaner
   factory_girl_rails
   faker
@@ -360,6 +365,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   mysql2
+  poltergeist
   pry
   rails (~> 4.2.0)
   rails-assets-jquery (~> 1.11)!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,9 +28,10 @@ jQuery(function($) {
     return value == '' || value.match(/^(([\w\.-]+|\*):)*([\w\.-]+|\*)$/);
   };
 
+
   $.fn.form.settings.rules['future_date'] = function(value) {
     if (value == '') return true;
     var now = new Date().getTime();
-    return (now < new Date(value).getTime());
+    return (now < Date.parse(value));
   };
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require semantic-ui
+//= require pickadate
 //= require aaf-layout
 
 jQuery(function($) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,4 +27,10 @@ jQuery(function($) {
   $.fn.form.settings.rules['accession_permission_value'] = function(value) {
     return value == '' || value.match(/^(([\w\.-]+|\*):)*([\w\.-]+|\*)$/);
   };
+
+  $.fn.form.settings.rules['future_date'] = function(value) {
+    if (value == '') return true;
+    var now = new Date().getTime();
+    return (now < new Date(value).getTime());
+  };
 });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,8 @@
  * file per style scope.
  *
  *= require semantic-ui
+ *= require pickadate/lib/themes/classic
+ *= require pickadate/lib/themes/classic.date
  *= require aaf-layout
  *= require_tree .
  *= require_self

--- a/app/controllers/api/attributes_controller.rb
+++ b/app/controllers/api/attributes_controller.rb
@@ -84,11 +84,11 @@ module API
       provider
     end
 
-    def lookup_subject(provider, identifier)
-      if identifier[:shared_token]
-        find_subject_by_shared_token(identifier[:shared_token])
+    def lookup_subject(provider, attrs)
+      if attrs[:shared_token]
+        find_subject_by_shared_token(attrs[:shared_token])
       else
-        find_or_create_subject(provider, identifier)
+        find_or_create_subject(provider, attrs)
       end
     end
 
@@ -97,8 +97,8 @@ module API
         fail(BadRequest, 'The Subject was not known to this system')
     end
 
-    def find_or_create_subject(provider, identifier)
-      name, mail = identifier.values_at(:name, :mail)
+    def find_or_create_subject(provider, attrs)
+      name, mail = attrs.values_at(:name, :mail)
 
       if name.nil?
         fail(BadRequest, 'The Subject name was not provided, but is required')
@@ -107,11 +107,12 @@ module API
                          'but is required')
       end
 
-      Subject.find_by_mail(mail) || invite_subject(provider, name, mail)
+      Subject.find_by_mail(mail) || invite_subject(provider, attrs)
     end
 
-    def invite_subject(provider, name, mail)
-      create_invitation(provider, name: name, mail: mail)
+    def invite_subject(provider, attrs)
+      expires = attrs[:expires] || 4.weeks.from_now.to_date
+      create_invitation(provider, attrs.permit(:name, :mail), expires)
     end
   end
 end

--- a/app/controllers/concerns/create_invitation.rb
+++ b/app/controllers/concerns/create_invitation.rb
@@ -1,14 +1,14 @@
 module CreateInvitation
   delegate :image_url, to: :view_context
 
-  def create_invitation(provider, subject_attrs)
+  def create_invitation(provider, subject_attrs, expires)
     Invitation.transaction do
       audit_attrs = {
         audit_comment: 'Created incomplete Subject for Invitation'
       }
 
       subject = Subject.create!(subject_attrs.merge(audit_attrs))
-      invitation = provider.invite(subject)
+      invitation = provider.invite(subject, expires)
       deliver(invitation)
       subject
     end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -10,10 +10,17 @@ class Invitation < ActiveRecord::Base
 
   validates :identifier, format: /\A[\w-]+\z/
 
+  validate :must_not_be_preexpired
+
   scope :current, -> { where(arel_table[:expires].gt(Time.now)) }
   scope :available, -> { current.where(used: false) }
 
   def expired?
-    expires < Time.now
+    expires && expires < Time.now
+  end
+
+  def must_not_be_preexpired
+    return if persisted?
+    errors.add(:expires, 'must be in the future') if expired?
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -27,14 +27,14 @@ class Provider < ActiveRecord::Base
     [Provider.identifier_prefix, identifier].join(':')
   end
 
-  def invite(subject)
+  def invite(subject, expires)
     identifier = SecureRandom.urlsafe_base64(19)
 
     message = "Created invitation for #{subject.name}"
 
     attrs = { subject_id: subject.id, identifier: identifier,
               name: subject.name, mail: subject.mail,
-              expires: 1.month.from_now, audit_comment: message }
+              expires: expires, audit_comment: message }
 
     invitations.create!(attrs)
   end

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -43,5 +43,5 @@
 <%- end -%>
 
 <%= validate_form('#new_invitation', :invitation) do -%>
-  <%= auto_validate(@invitation, :name, :mail) %>
+  <%= auto_validate(@invitation, :name, :mail, :expires) %>
 <%- end -%>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -44,4 +44,5 @@
 
 <%= validate_form('#new_invitation', :invitation) do -%>
   <%= auto_validate(@invitation, :name, :mail, :expires) %>
+  <%= validate_field(:expires, future_date: 'Please enter an expiry date in the future') %>
 <%- end -%>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -20,6 +20,11 @@
     <%= f.text_field(:mail) %>
   <%- end -%>
 
+  <%= field_block do -%>
+    <%= f.label(:expires) %>
+    <%= f.date_field(:expires) %>
+  <%- end -%>
+
   <div class="line-of-buttons">
     <%- if permitted?("providers:#{@provider.id}:invitations:create") -%>
       <%= button_tag(type: 'submit', class: 'large green icon') do -%>

--- a/doc/api/v1/subjects.md
+++ b/doc/api/v1/subjects.md
@@ -74,6 +74,7 @@ There are 3 keys way to identify a subject within an API request:
 | shared_token | string  | auEduPersonSharedToken for the identity whose attributes the client wishes to modify | Yes |
 | name | string | The name for the target identity whose attributes the client wishes to modify | Yes |
 | mail | string | The email address for the target identity whose attributes the client wishes to modify | Yes |
+| expires | string | The expiry date of the invitation, as a YYYY-mm-dd formatted date. |
 | allow_create | boolean | If a shared_token, name and mail attribute is provided in the request and an existing identity for the shared_token is not present within IdE should a full record (including attribute manipulation for this request) be created | Yes |
 
 #### attribute
@@ -121,7 +122,27 @@ Specification via mail and name:
   {
     "name":      "eduPersonEntitlement",
     "value":      "urn:mace:aaf.edu.au:ide:researcher:2",
-    "_destroy": true  }]
+    "_destroy":   true
+  }]
+}
+```
+
+Specification with invitation expiry time:
+
+```
+{
+  "subject": {
+    "mail": "john.doe@example.com",
+    "name": "John Doe",
+    "expires": "2018-01-01'
+  },
+  "provider": {
+    "identifier": "urn:mace:aaf.edu.au:ide:providers:provider1"
+  },
+  "attributes": [{
+    "name":      "eduPersonEntitlement",
+    "value":      "urn:mace:aaf.edu.au:ide:researcher:1"
+  }]
 }
 ```
 

--- a/spec/controllers/api/attributes_controller_spec.rb
+++ b/spec/controllers/api/attributes_controller_spec.rb
@@ -269,6 +269,22 @@ module API
           it_behaves_like 'attribute creation failure',
                           /Subject name was not provided/
         end
+
+        context 'specifying the expiry' do
+          let(:expires) { 8.weeks.from_now.to_date }
+
+          let(:subject_params) do
+            {
+              name: object.name, mail: object.mail, expires: expires.iso8601
+            }
+          end
+
+          it_behaves_like 'invitation of new subject'
+
+          it 'expires the invitation when expected' do
+            expect(Invitation.last.expires).to eq(expires)
+          end
+        end
       end
     end
   end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -168,13 +168,6 @@ RSpec.describe InvitationsController, type: :controller do
       it { is_expected.to have_assigned(:invitation, invitation) }
     end
 
-    context 'for an expired invite' do
-      let(:invitation) { create(:invitation, expires: 1.month.ago) }
-      before { run }
-      it { is_expected.to render_template('invitations/expired') }
-      it { is_expected.to have_assigned(:invitation, invitation) }
-    end
-
     context 'for a valid invite' do
       before { run }
       it { is_expected.to render_template('invitations/show') }

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe InvitationsController, type: :controller do
       it 'assigns the invitation' do
         expect(assigns[:invitation]).to be_a_new(Invitation)
       end
+
+      it 'defaults to 4 week expiry' do
+        expect(assigns[:invitation].expires).to eq(4.weeks.from_now.to_date)
+      end
     end
   end
 
@@ -62,7 +66,8 @@ RSpec.describe InvitationsController, type: :controller do
 
     let(:attrs) do
       attributes_for(:subject).slice(:name, :mail)
-        .merge(provider_id: provider.id)
+        .merge(provider_id: provider.id,
+               expires: 1.week.from_now.to_date.xmlschema)
     end
 
     def run
@@ -79,6 +84,11 @@ RSpec.describe InvitationsController, type: :controller do
 
       it 'creates the invitation' do
         expect { run }.to change(Invitation, :count).by(1)
+      end
+
+      it 'sets the expiry' do
+        run
+        expect(Invitation.last.expires).to eq(Time.parse(attrs[:expires]))
       end
 
       it 'sets flash success' do

--- a/spec/feature/accept_invitation_spec.rb
+++ b/spec/feature/accept_invitation_spec.rb
@@ -31,11 +31,13 @@ RSpec.feature 'Visiting the invitation page', type: :feature do
   end
 
   context 'with an expired invitation' do
-    given(:invitation) { create(:invitation, expires: 1.day.ago) }
+    given!(:invitation) { create(:invitation, expires: 1.second.from_now) }
 
     scenario 'attempting to accept the invitation' do
-      visit "/invitations/#{invitation.identifier}"
-      expect(page).to have_content('invitation expired')
+      Timecop.travel(1.minute) do
+        visit "/invitations/#{invitation.identifier}"
+        expect(page).to have_content('invitation expired')
+      end
     end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -17,19 +17,27 @@ RSpec.describe Invitation, type: :model do
     it { is_expected.to allow_value('abcdefg1234').for(:identifier) }
     it { is_expected.not_to allow_value('abc!').for(:identifier) }
     it { is_expected.not_to allow_value("abc\ndef").for(:identifier) }
+
+    it { is_expected.not_to allow_value(1.day.ago).for(:expires) }
+
+    context 'when persisted' do
+      subject { create(:invitation) }
+      it { is_expected.to allow_value(1.day.ago).for(:expires) }
+    end
   end
 
   context '#expired?' do
     around { |e| Timecop.freeze { e.run } }
-    subject { create(:invitation, expires: expires) }
+
+    subject! { create(:invitation, expires: expires) }
+    let(:expires) { 1.second.from_now }
 
     context 'with `expires` in the future' do
-      let(:expires) { 1.second.from_now }
       it { is_expected.not_to be_expired }
     end
 
     context 'with `expires` in the past' do
-      let(:expires) { 1.second.ago }
+      before { Timecop.travel(1.minute.from_now) }
       it { is_expected.to be_expired }
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -46,9 +46,10 @@ RSpec.describe Provider, type: :model do
   context '#invite' do
     let(:user) { create(:subject) }
     let(:provider) { create(:provider) }
+    let(:expires) { rand(10).weeks.from_now }
 
     def run
-      provider.invite(user)
+      provider.invite(user, expires)
     end
 
     it 'creates the invitation' do
@@ -65,7 +66,7 @@ RSpec.describe Provider, type: :model do
     it 'sets the expiry' do
       Timecop.freeze do
         run
-        expect(user.invitations.last.expires.to_i).to eq(1.month.from_now.to_i)
+        expect(user.invitations.last.expires.to_i).to eq(expires.to_i)
       end
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Provider, type: :model do
   context '#invite' do
     let(:user) { create(:subject) }
     let(:provider) { create(:provider) }
-    let(:expires) { rand(10).weeks.from_now }
+    let(:expires) { (1 + rand(10)).weeks.from_now }
 
     def run
       provider.invite(user, expires)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'capybara/rspec'
+require 'capybara/poltergeist'
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -32,10 +33,6 @@ module NoTransactionalFixtures
 end
 
 RSpec.configure do |config|
-  config.before(:each, type: :feature, js: true) do
-    page.driver.block_unknown_urls
-  end
-
   config.use_transactional_fixtures = true
   config.include ControllerMatchers, type: :controller
   config.include AliasedMatchers
@@ -52,7 +49,7 @@ RSpec.configure do |config|
     end
   end
 
-  Capybara.javascript_driver = :webkit
+  Capybara.javascript_driver = :poltergeist
 
   config.before(:suite) { DatabaseCleaner.strategy = :truncation }
   config.before(:each, type: :feature) { DatabaseCleaner.start }


### PR DESCRIPTION
Allows the expiry time of an invitation to be set by the provider (via web or API)

Re: #45