### PR TITLE
Subject merge

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -22,8 +22,12 @@ class Subject < ActiveRecord::Base
       message = 'Provisioned account via invitation'
       update_attributes!(attrs.merge(audit_comment: message, complete: true))
 
-      invitation.update_attributes!(used: true,
+      invited_subject = invitation.subject
+
+      invitation.update_attributes!(used: true, subject: self,
                                     audit_comment: "Accepted by #{name}")
+
+      merge(invited_subject) if invited_subject != self
     end
   end
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -36,7 +36,6 @@ class Subject < ActiveRecord::Base
       merge_roles(other)
       merge_attributes(other)
 
-      other.reload # HACK: Why is this needed? Tests fail without it.
       other.audit_comment = "Merged into Subject #{id}"
       other.destroy!
     end
@@ -50,9 +49,6 @@ class Subject < ActiveRecord::Base
 
   def merge_roles(other)
     other.subject_role_assignments.each do |role_assoc|
-      role_assoc.audit_comment = "Merged role into Subject #{id}"
-      role_assoc.destroy!
-
       next if role_ids.include?(role_assoc.role_id)
 
       subject_role_assignments
@@ -63,9 +59,6 @@ class Subject < ActiveRecord::Base
 
   def merge_attributes(other)
     other.provided_attributes.each do |other_attr|
-      other_attr.audit_comment = "Merged attribute into Subject #{id}"
-      other_attr.destroy!
-
       attrs = other_attr.attributes
               .slice(*%w(name value permitted_attribute_id))
 

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -28,11 +28,12 @@ module Authentication
       invitation = Invitation.where(identifier: session[:invite])
                    .available.first!
 
-      Audited.audit_class.as_user(invitation.subject) do
-        invitation.subject.accept(invitation, attrs)
+      subject = subject_scope(attrs).first || invitation.subject
+      Audited.audit_class.as_user(subject) do
+        subject.accept(invitation, attrs)
       end
 
-      invitation.subject
+      subject
     end
 
     def update_subject(subject, attrs)

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -59,7 +59,6 @@ module Authentication
     def check_subject(subject, attrs)
       require_nil_or_equal(subject.targeted_id, attrs[:targeted_id])
       require_nil_or_equal(subject.shared_token, attrs[:shared_token])
-      subject
     end
 
     def require_nil_or_equal(actual, expected)

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -16,7 +16,8 @@ module Authentication
       session = env['rack.session']
       return accept_invitation(session, attrs) if session.try(:key?, :invite)
 
-      Subject.find_or_initialize_by(attrs.slice(:targeted_id)).tap do |subject|
+      subject_scope(attrs).find_or_initialize_by({}).tap do |subject|
+        check_subject(subject, attrs)
         update_subject(subject, attrs)
       end
     end
@@ -46,6 +47,24 @@ module Authentication
           subject.save!
         end
       end
+    end
+
+    def subject_scope(attrs)
+      t = Subject.arel_table
+      Subject.where(t[:targeted_id].eq(attrs[:targeted_id])
+        .or(t[:shared_token].eq(attrs[:shared_token])))
+    end
+
+    def check_subject(subject, attrs)
+      require_nil_or_equal(subject.targeted_id, attrs[:targeted_id])
+      require_nil_or_equal(subject.shared_token, attrs[:shared_token])
+      subject
+    end
+
+    def require_nil_or_equal(actual, expected)
+      return if actual.nil? || actual == expected
+      fail("Unable to update Subject, incoming value `#{expected}` did not " \
+           "match existing value `#{actual}`")
     end
   end
 end

--- a/spec/lib/authentication/subject_receiver_spec.rb
+++ b/spec/lib/authentication/subject_receiver_spec.rb
@@ -165,6 +165,21 @@ module Authentication
           expect(obj.audits.last.user).to eq(obj)
         end
 
+        context 'when a merge is required' do
+          let!(:object) { create(:subject, attrs.merge(complete: false)) }
+
+          it 'deletes the invited subject' do
+            expect { subject.subject(env, attrs) }
+              .to change(Subject, :count).by(-1)
+          end
+
+          it 'reassigns the invitation' do
+            expect { subject.subject(env, attrs) }
+              .to change { invitation.reload.subject }
+              .to(object)
+          end
+        end
+
         context 'when the invitation fails to save' do
           before do
             allow_any_instance_of(Invitation).to receive(:update_attributes!)


### PR DESCRIPTION
Merges an invited subject into an existing one, if the existing subject accepts the invitation.

Fixes the scenarios described in #35 and #36 