### PR TITLE
Allow providers to be marked as public/private, and hide private providers in the UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'audited-activerecord'
 gem 'rapid-rack'
 gem 'accession'
 gem 'aaf-lipstick', git: 'https://github.com/ausaccessfed/aaf-lipstick',
-                    branch: 'bugfix/blank-date-picker'
+                    branch: 'develop'
 gem 'valhammer'
 
 gem 'unicorn', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ausaccessfed/aaf-lipstick
-  revision: 3c49ee858abb5a6509b18d79416c07ac66b4dd5f
-  branch: bugfix/blank-date-picker
+  revision: c9c1f3e4311003433e30c84f45d8fb7d1b26d353
+  branch: develop
   specs:
     aaf-lipstick (1.1.0)
       actionview (~> 4.1)
@@ -207,7 +207,7 @@ GEM
     rails-assets-jquery (1.11.2)
     rails-assets-pickadate (3.5.4)
       rails-assets-jquery (>= 1.7)
-    rails-assets-semantic-ui (1.12.0)
+    rails-assets-semantic-ui (1.12.1)
       rails-assets-jquery (>= 1.8)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -2,7 +2,7 @@ class ProvidersController < ApplicationController
   def index
     public_action
     @filter = params[:filter]
-    @providers = Provider.filter(@filter).order(:name)
+    @providers = Provider.visible_to(subject).filter(@filter).order(:name)
                  .paginate(page: params[:page])
   end
 

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -62,7 +62,7 @@ class ProvidersController < ApplicationController
   private
 
   def provider_params
-    params.require(:provider).permit(:name, :description, :identifier)
+    params.require(:provider).permit(:name, :description, :identifier, :public)
   end
 
   def create_provider

--- a/app/controllers/requested_enhancements_controller.rb
+++ b/app/controllers/requested_enhancements_controller.rb
@@ -55,7 +55,7 @@ class RequestedEnhancementsController < ApplicationController
   def select_provider
     public_action
     @filter = params[:filter]
-    @providers = Provider.filter(@filter).order(:name)
+    @providers = Provider.visible_to(subject).filter(@filter).order(:name)
                  .paginate(page: params[:page])
   end
 

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -28,6 +28,15 @@
     <%= f.text_field :description %>
   <%- end -%>
 
+  <%= field_block(class: 'inline') do -%>
+    <%= f.check_box(:public) %>
+    <%= f.label(:public) do -%>
+      Public
+      <%= field_help_text('A private Enhancement Provider is only visible to ' \
+                          'users who have been given access') %>
+    <%- end -%>
+  <%- end -%>
+
   <div class="line-of-buttons">
     <%= f.button(class: 'large green icon') do -%>
       <%= icon_tag('checkmark') %>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -17,6 +17,21 @@
       <td>Identifier</td>
       <td><%= @provider.identifier %></td>
     </tr>
+    <tr>
+      <td>Visibility</td>
+      <%- if @provider.public? -%>
+        <td class="positive">Public</td>
+      <%- else -%>
+        <td class="warning">
+          <p>Private</p>
+          <p>
+            <strong>Note:</strong> Users will not be able to request enhancement
+            from this provider, and may not be aware that it exists in the
+            system.
+          </p>
+        </td>
+      <%- end -%>
+    </tr>
   </tbody>
 </table>
 

--- a/db/migrate/20150427034024_add_public_field_to_providers.rb
+++ b/db/migrate/20150427034024_add_public_field_to_providers.rb
@@ -1,0 +1,7 @@
+class AddPublicFieldToProviders < ActiveRecord::Migration
+  def change
+    change_table :providers do |t|
+      t.boolean :public, null: false, default: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150417013617) do
+ActiveRecord::Schema.define(version: 20150427034024) do
 
   create_table "api_subject_role_assignments", force: :cascade do |t|
     t.integer  "api_subject_id", limit: 4, null: false
@@ -114,14 +114,25 @@ ActiveRecord::Schema.define(version: 20150417013617) do
   add_index "provided_attributes", ["subject_id", "permitted_attribute_id"], name: "provided_attributes_unique_attribute", unique: true, using: :btree
 
   create_table "providers", force: :cascade do |t|
-    t.string   "name",        limit: 255,              null: false
-    t.string   "description", limit: 255, default: "", null: false
-    t.string   "identifier",  limit: 255,              null: false
+    t.string   "name",        limit: 255,                null: false
+    t.string   "description", limit: 255, default: "",   null: false
+    t.string   "identifier",  limit: 255,                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "public",      limit: 1,   default: true, null: false
   end
 
   add_index "providers", ["identifier"], name: "index_providers_on_identifier", unique: true, using: :btree
+
+  create_table "provisioned_subjects", force: :cascade do |t|
+    t.integer  "subject_id",  limit: 4, null: false
+    t.integer  "provider_id", limit: 4, null: false
+    t.datetime "expires_at"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+  end
+
+  add_index "provisioned_subjects", ["subject_id", "provider_id"], name: "index_provisioned_subjects_on_subject_id_and_provider_id", unique: true, using: :btree
 
   create_table "requested_enhancements", force: :cascade do |t|
     t.integer  "subject_id",     limit: 4,                    null: false

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -17,6 +17,27 @@ RSpec.describe ProvidersController, type: :controller do
     it { is_expected.to render_template('providers/index') }
     it { is_expected.to have_assigned(:providers, include(provider)) }
 
+    context 'with a private provider' do
+      let(:secret_squirrel) { create(:provider, public: false) }
+
+      it 'excludes the provider' do
+        expect(assigns[:providers]).not_to include(secret_squirrel)
+      end
+
+      context 'when the user has access' do
+        let(:user) do
+          create(:subject).tap do |user|
+            role = create(:role, provider: secret_squirrel)
+            create(:subject_role_assignment, subject: user, role: role)
+          end
+        end
+
+        it 'includes the provider' do
+          expect(assigns[:providers]).to include(secret_squirrel)
+        end
+      end
+    end
+
     context 'as a non-admin' do
       let(:user) { create(:subject) }
       it { is_expected.to have_http_status(:ok) }

--- a/spec/controllers/requested_enhancements_controller_spec.rb
+++ b/spec/controllers/requested_enhancements_controller_spec.rb
@@ -258,5 +258,26 @@ RSpec.describe RequestedEnhancementsController, type: :controller do
         end
       end
     end
+
+    context 'with a private provider' do
+      let(:secret_squirrel) { create(:provider, public: false) }
+
+      it 'excludes the provider' do
+        expect(assigns[:providers]).not_to include(secret_squirrel)
+      end
+
+      context 'when the user has access' do
+        let(:user) do
+          create(:subject).tap do |user|
+            role = create(:role, provider: secret_squirrel)
+            create(:subject_role_assignment, subject: user, role: role)
+          end
+        end
+
+        it 'includes the provider' do
+          expect(assigns[:providers]).to include(secret_squirrel)
+        end
+      end
+    end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -119,4 +119,53 @@ RSpec.describe Provider, type: :model do
         .to include("providers:#{provider.id}:attributes:create")
     end
   end
+
+  context '::visible_to' do
+    let(:public_provider) { create(:provider, public: true) }
+    let(:private_provider) { create(:provider, public: false) }
+    let(:role) { create(:role, provider: private_provider) }
+
+    subject { Provider.visible_to(user).all }
+
+    context 'for a Subject' do
+      let(:user) { create(:subject) }
+
+      it { is_expected.to include(public_provider) }
+      it { is_expected.not_to include(private_provider) }
+
+      context 'with access' do
+        before { create(:subject_role_assignment, subject: user, role: role) }
+        it { is_expected.to include(private_provider) }
+      end
+
+      context 'with admin access' do
+        let(:user) { create(:subject, :authorized, permission: '*') }
+
+        it { is_expected.to include(public_provider) }
+        it { is_expected.to include(private_provider) }
+      end
+    end
+
+    context 'for an APISubject' do
+      let(:user) { create(:api_subject) }
+
+      it { is_expected.to include(public_provider) }
+      it { is_expected.not_to include(private_provider) }
+
+      context 'with access' do
+        before do
+          create(:api_subject_role_assignment, api_subject: user, role: role)
+        end
+
+        it { is_expected.to include(private_provider) }
+      end
+
+      context 'with admin access' do
+        let(:user) { create(:api_subject, :authorized, permission: '*') }
+
+        it { is_expected.to include(public_provider) }
+        it { is_expected.to include(private_provider) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Private providers are only visible to users who have a role assigned for that provider.

We don't have a providers list on an API endpoint so this doesn't change anything API-related aside from having the ability to scope the providers list to those visible to an APISubject.

Technically this doesn't hide attributes provided by private providers, but technically that's only part of #58. (I'll tackle it there as a secondary concern).