### PR TITLE
Clean up provisioned subjects correctly

### DIFF
--- a/app/models/provisioned_subject.rb
+++ b/app/models/provisioned_subject.rb
@@ -5,4 +5,6 @@ class ProvisionedSubject < ActiveRecord::Base
   valhammer
 
   validates :provider, uniqueness: { scope: :subject }
+
+  scope :expired, -> { where(arel_table[:expires_at].lt(Time.now.utc)) }
 end

--- a/bin/remove_expired_data
+++ b/bin/remove_expired_data
@@ -4,6 +4,29 @@ require_relative '../config/environment.rb'
 
 class RemoveExpiredData
   def self.perform
+    transaction { clean_invitations }
+    transaction { clean_provisioned_subjects }
+  end
+
+  def self.transaction(&bl)
+    ActiveRecord::Base.transaction(&bl)
+  end
+
+  def self.clean_provisioned_subjects
+    ProvisionedSubject.expired.find_each do |provisioned_subject|
+      subject = provisioned_subject.subject
+      provider = provisioned_subject.provider
+      subject.provided_attributes.for_provider(provider).find_each do |attr|
+        attr.audit_comment =
+          'Removed attribute relating to expired relationship'
+        attr.destroy!
+      end
+
+      provisioned_subject.destroy!
+    end
+  end
+
+  def self.clean_invitations
     Invitation.available.find_each do |invitation|
       next unless invitation.expired?
 

--- a/spec/bin/remove_expired_data_spec.rb
+++ b/spec/bin/remove_expired_data_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'bin/remove_expired_data' do
                                   permitted_attribute: permitted_attribute)
     end
 
-    it 'removes the removes the attribute' do
+    it 'removes the attribute' do
       expect { run }.to change(ProvidedAttribute, :count).by(-1)
       expect { attribute.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end

--- a/spec/bin/remove_expired_data_spec.rb
+++ b/spec/bin/remove_expired_data_spec.rb
@@ -61,4 +61,43 @@ RSpec.describe 'bin/remove_expired_data' do
       object.reload
     end
   end
+
+  context 'with an expired provisioned subject' do
+    let(:provisioned_subject) do
+      create(:provisioned_subject, expires_at: 1.minute.ago)
+    end
+
+    let(:permitted_attribute) do
+      create(:permitted_attribute, provider: provider)
+    end
+
+    let(:provider) { provisioned_subject.provider }
+    let(:object) { provisioned_subject.subject }
+    let!(:attribute) do
+      create(:provided_attribute, subject: object,
+                                  permitted_attribute: permitted_attribute)
+    end
+
+    it 'removes the removes the attribute' do
+      expect { run }.to change(ProvidedAttribute, :count).by(-1)
+      expect { attribute.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'removes the provisioned subject' do
+      expect { run }.to change(ProvisionedSubject, :count).by(-1)
+      expect { provisioned_subject.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'with a nonexpired provisioned subject' do
+    let!(:provisioned_subject) do
+      create(:provisioned_subject, expires_at: 1.hour.from_now)
+    end
+
+    it 'leaves the provisioned subject intact' do
+      expect { run }.not_to change(ProvisionedSubject, :count)
+      provisioned_subject.reload
+    end
+  end
 end


### PR DESCRIPTION
This was missed during the original changes to add expiration to subject / provider relationships.