### PR TITLE
Skip invitations with no subject which are expired

### DIFF
--- a/bin/remove_expired_data
+++ b/bin/remove_expired_data
@@ -31,6 +31,7 @@ class RemoveExpiredData
       next unless invitation.expired?
 
       subject = invitation.subject
+      next unless subject
 
       $stderr.puts("Removing placeholder Subject #{subject.id} " \
                    "(name=`#{subject.name}` mail=`#{subject.mail}`)")

--- a/spec/bin/remove_expired_data_spec.rb
+++ b/spec/bin/remove_expired_data_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe 'bin/remove_expired_data' do
         object.reload
       end
     end
+
+    context 'when the invitation has no subject' do
+      before do
+        object.audit_comment = 'Deleted by test'
+        object.destroy!
+      end
+
+      it 'skips the invitation' do
+        expect { run }.not_to change(Invitation, :count)
+      end
+    end
   end
 
   context 'with a nonexpired invitation' do


### PR DESCRIPTION
Triggered this bug while doing some final testing in my dev VM. Invitation#subject is nullable now but this script was never updated.