### PR TITLE
Show description for permitted/available attribute

### DIFF
--- a/app/views/permitted_attributes/index.html.erb
+++ b/app/views/permitted_attributes/index.html.erb
@@ -21,6 +21,7 @@
       <tr>
         <th>Name</th>
         <th>Value</th>
+        <th>Description</th>
         <th/>
       </tr>
     </thead>
@@ -30,6 +31,7 @@
         <tr>
           <td><%= attribute.name %></td>
           <td><%= attribute.value %></td>
+          <td><%= attribute.description %></td>
           <td class="right aligned">
             <%- if permitted?('admin:permitted_attributes:delete') -%>
               <%= delete_button_tag([@provider, permitted_attribute], text: 'Remove') %>
@@ -56,6 +58,7 @@
       <tr>
         <th>Name</th>
         <th>Value</th>
+        <th>Description</th>
         <th/>
       </tr>
     </thead>
@@ -64,6 +67,7 @@
         <tr>
           <td><%= attribute.name %></td>
           <td><%= attribute.value %></td>
+          <td><%= attribute.description %></td>
           <td class="right aligned">
             <%- if permitted?('admin:permitted_attributes:create') -%>
               <%= form_tag(provider_permitted_attributes_path(@provider), method: 'post') do |f| -%>


### PR DESCRIPTION
Makes it more clear what the purpose of an attribute is, when deciding which attributes are permitted for a given provider.