### PR TITLE
Config: use secure session cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,6 +4,7 @@ redis_namespace = "ide-service:#{Rails.env}:session"
 session_store_opts = {
   redis_server: "redis://127.0.0.1:6379/0/#{redis_namespace}",
   expire_in: 3600,
+  secure: true,
   key: '_ide-service_session'
 }
 


### PR DESCRIPTION
Hi @bradleybeddoes , @smangelsdorf 

Rails defaults to not marking cookies as secure.

Prevent cookie theft over plain http: mark cookies as secure

This will apply to the Ruby stack across the board - this is identical to the PR I sent for the reporting service: ausaccessfed/reporting-service#181

Cheers,
Vlad